### PR TITLE
Add routes view and controller for lessons

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,9 @@ Metrics/AbcSize:
 Style/ClassAndModuleChildren:
   Exclude:
     - app/controllers/users/omniauth_callbacks_controller.rb
+
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+
+Rails/Rails/InverseOf:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,10 @@ gem 'omniauth-rails_csrf_protection'
 
 gem 'kaminari'
 
+# Videoplayer for rails [https://github.com/sadiqmmm/plyr-rails]
+gem 'plyr-rails'
+
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'kaminari'
 # Videoplayer for rails [https://github.com/sadiqmmm/plyr-rails]
 gem 'plyr-rails'
 
-
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 
@@ -63,7 +62,6 @@ gem 'bootsnap', require: false
 
 # Template language
 gem 'slim-rails', '~> 3.1', '>= 3.5.1'
-
 
 # Front-end framework
 gem 'bootstrap', '~> 5.2'

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ gem 'kaminari'
 # Videoplayer for rails [https://github.com/sadiqmmm/plyr-rails]
 gem 'plyr-rails'
 
-
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'kaminari'
 # Videoplayer for rails [https://github.com/sadiqmmm/plyr-rails]
 gem 'plyr-rails'
 
+
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"
 
@@ -62,6 +63,7 @@ gem 'bootsnap', require: false
 
 # Template language
 gem 'slim-rails', '~> 3.1', '>= 3.5.1'
+
 
 # Front-end framework
 gem 'bootstrap', '~> 5.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
     parser (3.1.2.1)
       ast (~> 2.4.1)
     pg (1.4.3)
+    plyr-rails (3.5.6)
     popper_js (2.11.5)
     public_suffix (5.0.0)
     puma (5.6.4)
@@ -374,6 +375,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 1.1, >= 1.1.1)
   omniauth-rails_csrf_protection
   pg (~> 1.1)
+  plyr-rails
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)
   rails-i18n (~> 7.0, >= 7.0.5)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,15 +1,32 @@
 @import "bootstrap";
 @import "_hero";
 
+// body
+body {
+  background-color: rgb(248, 249, 250);
+}
+
+// links
+.custom-breadcrumbs a {
+  text-decoration: none;
+}
+
+// titles
 h1 {
   font-size: 20px;
 }
 
+h2 {
+  font-size: 18px;
+}
+
+// forms
 .standart-form {
   width: 400px;
   border: 1px solid gray;
   border-radius: 12px;
   padding: 24px;
+  background: #ffffff;
 }
 
 // icons
@@ -44,4 +61,19 @@ i svg {
 // margins
 .custom-mr-12 {
   margin-right: 12px;
+}
+
+// lists
+.custom-list-group {
+  width: 400px;
+}
+
+// pagination
+.custom-pagination-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.pagination li {
+  margin: 0 8px;
 }

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,0 +1,2 @@
+class LessonsController < ApplicationController
+end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,11 +1,12 @@
+# frozen_string_literal: true
+
 class LessonsController < ApplicationController
-  before_action :lesson_find, only: [:show, :edit, :update]
+  before_action :lesson_find, only: %i[show edit update]
   def index
     @lessons = Lesson.all
   end
 
-  def show
-  end
+  def show; end
 
   def new
     @lesson = Lesson.new
@@ -20,18 +21,17 @@ class LessonsController < ApplicationController
     end
   end
 
-  def edit
+  def edit; end
+
+  def update; end
+
+  private
+
+  def lesson_params
+    params.require(:lesson).permit(:title, :description, :status, :video_link, :author_id, :category_id)
   end
 
-  def update
+  def lesson_find
+    @lesson = Lesson.find(params[:id])
   end
-private
-def lesson_params
-  params.require(:lesson).permit(:title, :description, :status, :video_link, :author_id , :category_id)
-end
-
-def lesson_find
-  @lesson = Lesson.find(params[:id])
-end
-
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -12,7 +12,7 @@ class LessonsController < ApplicationController
   end
 
   def create
-    @lesson = curent_user.lessons.new(lesson_params)
+    @lesson = current_user.lessons.new(lesson_params)
     if @lesson.save
       redirect_to @lesson
     else

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -23,18 +23,17 @@ class LessonsController < ApplicationController
 
   def edit; end
 
-  def update;
+  def update
     if @lesson.update(lesson_params)
       redirect_to @lesson
     else
       render :edit, status: :unprocessable_entity
     end
-   end
+  end
 
-   def destroy
+  def destroy
     @lesson.destroy
-   end
-
+  end
 
   private
 
@@ -43,6 +42,6 @@ class LessonsController < ApplicationController
   end
 
   def lesson_find
-    @lesson = current_user.lessons.find(params[:id])
+    @lesson = Lesson.all.find(params[:id])
   end
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -23,7 +23,18 @@ class LessonsController < ApplicationController
 
   def edit; end
 
-  def update; end
+  def update;
+    if @lesson.update(lesson_params)
+      redirect_to @lesson
+    else
+      render :edit, status: :unprocessable_entity
+    end
+   end
+
+   def destroy
+    @lesson.destroy
+   end
+
 
   private
 
@@ -32,6 +43,6 @@ class LessonsController < ApplicationController
   end
 
   def lesson_find
-    @lesson = Lesson.find(params[:id])
+    @lesson = current_user.lessons.find(params[:id])
   end
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,2 +1,37 @@
 class LessonsController < ApplicationController
+  before_action :lesson_find, only: [:show, :edit, :update]
+  def index
+    @lessons = Lesson.all
+  end
+
+  def show
+  end
+
+  def new
+    @lesson = Lesson.new
+  end
+
+  def create
+    @lesson = curent_user.lessons.new(lesson_params)
+    if @lesson.save
+      redirect_to @lesson
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+  end
+private
+def lesson_params
+  params.require(:lesson).permit(:title, :description, :status, :video_link, :author_id , :category_id)
+end
+
+def lesson_find
+  @lesson = Lesson.find(params[:id])
+end
+
 end

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -1,0 +1,2 @@
+module LessonsHelper
+end

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module LessonsHelper
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,3 +6,4 @@ import "controllers"
 //= require jquery3
 //= require popper
 //= require bootstrap
+//= require plyr

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -6,4 +6,6 @@ class Category < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
+
+  has_many :lessons
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -3,5 +3,5 @@
 class Lesson < ApplicationRecord
   paginates_per MAX_ITEMS_PER_PAGE
   has_many :comments, dependent: :destroy
-  belongs_to :author, class_name: "User", foreign_key: "author_id"
+  belongs_to :author, class_name: 'User'
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -3,4 +3,5 @@
 class Lesson < ApplicationRecord
   paginates_per MAX_ITEMS_PER_PAGE
   has_many :comments, dependent: :destroy
+  belongs_to :author, class_name: "User", foreign_key: "author_id"
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -4,4 +4,7 @@ class Lesson < ApplicationRecord
   paginates_per MAX_ITEMS_PER_PAGE
   has_many :comments, dependent: :destroy
   belongs_to :author, class_name: 'User'
+
+  validates :title, presence: true
+  validates :description, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6 }
 
   has_many :comments, dependent: :destroy
+  has_many :lessons, class_name: "Lesson", foreign_key: "author_id"
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6 }
 
   has_many :comments, dependent: :destroy
-  has_many :lessons, class_name: "Lesson", foreign_key: "author_id"
+  has_many :lessons, class_name: 'Lesson', foreign_key: 'author_id'
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.provider = auth.provider

--- a/app/views/categories/_form.html.slim
+++ b/app/views/categories/_form.html.slim
@@ -1,16 +1,16 @@
 = form_with model: category do |form|
-  div.field.mt-3
+  .field.mt-3
     = form.label :name, class: "form-label"
     = form.text_field :name, class: "form-control"
     - category.errors.full_messages_for(:name).each do |message|
-      div = message
-  div.field.mt-3
+      .text-danger = message
+  .field.mt-3
     = form.label :description, class: "form-label"
     = form.text_area :description, class: "form-control"
     - category.errors.full_messages_for(:description).each do |message|
-      div = message
-  div.field.mt-3
-    = form.label :status, class: "form-label custom-mr-12"
-    = form.select :status, ['active', 'archived'], selected: 'active', class: "form-control"
-  div.field.mt-3
+      .text-danger = message
+  .input-group.mt-5
+    = form.label :status, class: "input-group-text"
+    = form.select :status, ['active', 'archived'], {}, {class: "form-select"}
+  .field.mt-5
     = form.submit t('global.forms.submit'), class: "btn btn-outline-primary"

--- a/app/views/categories/edit.html.slim
+++ b/app/views/categories/edit.html.slim
@@ -1,4 +1,16 @@
-h1 = t('.edit')
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = link_to t('global.categories'), categories_path
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = t('categories.edit.edit')
 
-ul = render "form", category: @category
-ul = link_to t('global.back'), categories_path
+.container-md.standart-form.shadow
+  h2 = t('.edit')
+  = render "form", category: @category

--- a/app/views/categories/index.html.slim
+++ b/app/views/categories/index.html.slim
@@ -1,10 +1,21 @@
-h1 = t('.categories')
-ul.list-group.list-group-numbered
-   - @categories.each do |category|
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = t('global.categories')
+
+.my-3.p-3.bg-body.rounded.shadow-sm
+  h1 = t('.categories')
+  - @categories.each do |category|
     - unless category.archived?
-      li.list-group-item
-        = link_to category.name, category, class: 'list-group-item'
-= paginate @categories
-.mt-3
-  = link_to t('.new'), new_category_path, class: 'btn btn-primary'
+    .border-bottom.p-3
+      div = link_to category.name, category
+      span.small = category.description
+  .mt-3.custom-pagination-wrapper
+    = paginate @categories
+  .mt-3
+    = link_to t('.new'), new_category_path, class: 'btn btn-outline-primary'
 

--- a/app/views/categories/new.html.slim
+++ b/app/views/categories/new.html.slim
@@ -1,5 +1,16 @@
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = link_to t('global.categories'), categories_path
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = t('categories.index.new')
+
 .container-md.standart-form.shadow
   h2 = t('categories.index.new')
-
-  ul = render "form", category: @category
-  ul = link_to t('global.back'), categories_path
+  = render "form", category: @category

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -1,12 +1,31 @@
-h1 = @category.name
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = link_to t('global.categories'), categories_path
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = @category.name
 
-p = @category.description
-.mt-3
-  = link_to t('global.edit'), edit_category_path(@category)
-.mt-3
-  = link_to t('global.back'), categories_path
-ul.list-group.list-group-numbered
-   - @category.lessons.each do |lesson|
-      li
-        = link_to lesson.title, lesson, class: "list-group-item"
-ul = link_to "New Lesson", new_lesson_path, class: "btn btn-primary"
+
+.my-3.p-3.bg-body.rounded.shadow-sm.d-flex.justify-content-between.align-items-end
+  div.flex-grow-1
+    h1.border-bottom.pb-2.mb-0 = @category.name
+    p = @category.description
+  div.small
+    = link_to t('global.edit'), edit_category_path(@category)
+
+.my-3.p-3.bg-body.rounded.shadow-sm
+  h2.border-bottom.pb-2.mb-0 = t('lessons.category_lessons')
+  - @category.lessons.each do |lesson|
+    .border-bottom.p-3
+      div = link_to lesson.title, lesson
+      span.small = lesson.description
+  .mt-3
+    a.btn.btn-outline-primary href = new_lesson_path
+      i == Octicons::Octicon.new("plus-circle").to_svg
+      = t('lessons.add_new_lesson')

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -5,3 +5,8 @@ p = @category.description
   = link_to t('global.edit'), edit_category_path(@category)
 .mt-3
   = link_to t('global.back'), categories_path
+ul.list-group.list-group-numbered
+   - @category.lessons.each do |lesson|
+      li
+        = link_to lesson.title, lesson, class: "list-group-item"
+ul = link_to "New Lesson", new_lesson_path, class: "btn btn-primary"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,4 +1,4 @@
-- menu_links  = {'home' => root_path, 'categories' => categories_path, 'about' => about_path}
+- menu_links  = {'categories' => categories_path, 'lessons' => lessons_path, 'about' => about_path}
 - menu_locales = {'English' => :en, 'Русский' => :ru}
 
 nav.navbar.navbar-expand-md.navbar-dark.bg-dark.p-1

--- a/app/views/layouts/_hero.html.slim
+++ b/app/views/layouts/_hero.html.slim
@@ -6,7 +6,7 @@ div.hero.bg-light
       = t('global.hero.lead')
   .hero_button-wrapper.mt-3
     - if user_signed_in?
-      a.btn.btn-outline-primary href = '#'
+      a.btn.btn-outline-primary href = new_lesson_path
         i == Octicons::Octicon.new("plus-circle").to_svg
         = t('lessons.add_new_lesson')
     - else

--- a/app/views/lessons/_form.html.slim
+++ b/app/views/lessons/_form.html.slim
@@ -1,24 +1,24 @@
 = form_with model: lesson do |form|
-  div
-    = form.label :title
-    = form.text_field :title
+  .field.mt-3
+    = form.label :title, class: "form-label"
+    = form.text_field :title, class: "form-control"
     - lesson.errors.full_messages_for(:title).each do |message|
-      div = message
-  div
-    = form.label :description
-    = form.text_area :description
+      .text-danger = message
+  .field.mt-3
+    = form.label :description, class: "form-label"
+    = form.text_area :description, class: "form-control"
     - lesson.errors.full_messages_for(:description).each do |message|
-      div = message
-  div
-    = form.label :video_link
-    = form.text_area :video_link
+      .text-danger = message
+  .field.mt-3
+    = form.label :video_link, class: "form-label"
+    = form.text_area :video_link, class: "form-control"
     - lesson.errors.full_messages_for(:video_link).each do |message|
-      div = message
-  div
-    = form.label :status
-    = form.select :status, ['active', 'archived'], selected: 'public'
-  div
-    = form.label :category
-    = form.collection_select :category_id, Category.all, :id, :name
-  div
-    = form.submit t('global.forms.submit')
+      .text-danger = message
+  .input-group.mt-5
+    = form.label :status, class: "input-group-text"
+    = form.select :status, ['active', 'archived'], {}, {class: "form-select"}
+  .input-group.mt-5
+    = form.label :category, class: "input-group-text"
+    = form.collection_select :category_id, Category.all, :id, :name, {}, {class: "form-select"}
+  .field.mt-5
+    = form.submit t('global.forms.submit'), class: "btn btn-outline-primary"

--- a/app/views/lessons/_form.html.slim
+++ b/app/views/lessons/_form.html.slim
@@ -1,0 +1,24 @@
+= form_with model: lesson do |form|
+  div
+    = form.label :title
+    = form.text_field :title
+    - lesson.errors.full_messages_for(:title).each do |message|
+      div = message
+  div
+    = form.label :description
+    = form.text_area :description
+    - lesson.errors.full_messages_for(:description).each do |message|
+      div = message
+  div
+    = form.label :video_link
+    = form.text_area :video_link
+    - lesson.errors.full_messages_for(:video_link).each do |message|
+      div = message
+  div
+    = form.label :status
+    = form.select :status, ['active', 'archived'], selected: 'public'
+  div
+    = form.label :category
+    = form.collection_select :category_id, Category.all, :id, :name
+  div
+    = form.submit t('global.forms.submit')

--- a/app/views/lessons/edit.html.slim
+++ b/app/views/lessons/edit.html.slim
@@ -1,4 +1,16 @@
-h1 Edit Lesson
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = link_to t('global.lessons'), lessons_path
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = t('lessons.edit_lesson')
 
-ul = render "form", lesson: @lesson
-ul = link_to "Back", lessons_path
+.container-md.standart-form.shadow
+  h2 = t('lessons.edit_lesson')
+  = render "form", lesson: @lesson

--- a/app/views/lessons/edit.html.slim
+++ b/app/views/lessons/edit.html.slim
@@ -1,0 +1,4 @@
+h1 Edit Lesson
+
+ul = render "form", lesson: @lesson
+ul = link_to "Back", lessons_path

--- a/app/views/lessons/index.html.slim
+++ b/app/views/lessons/index.html.slim
@@ -1,0 +1,7 @@
+h1 Lessons
+ul.list-group.list-group-numbered
+   - @lessons.each do |lesson|
+      li
+        = link_to lesson.title, lesson, class: "list-group-item"
+ul = link_to "New Lesson", new_lesson_path, class: "btn btn-primary"
+

--- a/app/views/lessons/index.html.slim
+++ b/app/views/lessons/index.html.slim
@@ -1,7 +1,20 @@
-h1 Lessons
-ul.list-group.list-group-numbered
-   - @lessons.each do |lesson|
-      li
-        = link_to lesson.title, lesson, class: "list-group-item"
-ul = link_to "New Lesson", new_lesson_path, class: "btn btn-primary"
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = t('global.lessons')
 
+.my-3.p-3.bg-body.rounded.shadow-sm
+  h1.border-bottom.pb-2.mb-0 = t('global.lessons')
+  - @lessons.each do |lesson|
+    .border-bottom.p-3
+      div = link_to lesson.title, lesson
+      span.small = lesson.description
+  .mt-3
+    - if user_signed_in?
+      a.btn.btn-outline-primary href = new_lesson_path
+        i == Octicons::Octicon.new("plus-circle").to_svg
+        = t('lessons.add_new_lesson')

--- a/app/views/lessons/new.html.slim
+++ b/app/views/lessons/new.html.slim
@@ -1,4 +1,16 @@
-h1 New Lesson
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = link_to t('global.lessons'), lessons_path
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = t('lessons.add_new_lesson')
 
-ul = render "form", lesson: @lesson
-ul = link_to "Back", lessons_path
+.container-md.standart-form.shadow
+  h2 = t('lessons.add_new_lesson')
+  = render "form", lesson: @lesson

--- a/app/views/lessons/new.html.slim
+++ b/app/views/lessons/new.html.slim
@@ -1,0 +1,4 @@
+h1 New Lesson
+
+ul = render "form", lesson: @lesson
+ul = link_to "Back", lessons_path

--- a/app/views/lessons/show.html.slim
+++ b/app/views/lessons/show.html.slim
@@ -1,6 +1,23 @@
-h1 = @lesson.title
-player.plyr__video-embed
-  iframe allow="autoplay" allowfullscreen="" allowtransparency="" src==@lesson.video_link
-p = @lesson.description
-ul = link_to "Edit", edit_lesson_path(@lesson)
-ul = link_to "Back", lessons_path
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = link_to t('global.lessons'), lessons_path
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = @lesson.title
+
+.my-3.p-3.bg-body.rounded.shadow-sm
+  h1 = @lesson.title
+  player.plyr__video-embed
+    iframe allow="autoplay" allowfullscreen="" allowtransparency="" src==@lesson.video_link
+  p = @lesson.description
+  .mt-3
+    - if user_signed_in?
+      a.btn.btn-outline-primary href = edit_lesson_path(@lesson)
+        i == Octicons::Octicon.new("pencil").to_svg
+        = t('global.edit')

--- a/app/views/lessons/show.html.slim
+++ b/app/views/lessons/show.html.slim
@@ -1,11 +1,6 @@
 h1 = @lesson.title
-<video poster="/path/to/poster.jpg" id="player" playsinline controls>
-    <source src="/path/to/video.mp4" type="video/mp4">
-    <source src="/path/to/video.webm" type="video/webm">
-
-    <!-- Captions are optional -->
-    <track kind="captions" label="English captions" src="/path/to/captions.vtt" srclang="en" default>
-</video>
+player.plyr__video-embed
+  iframe allow="autoplay" allowfullscreen="" allowtransparency="" src==@lesson.video_link
 p = @lesson.description
 ul = link_to "Edit", edit_lesson_path(@lesson)
 ul = link_to "Back", lessons_path

--- a/app/views/lessons/show.html.slim
+++ b/app/views/lessons/show.html.slim
@@ -1,0 +1,11 @@
+h1 = @lesson.title
+<video poster="/path/to/poster.jpg" id="player" playsinline controls>
+    <source src="/path/to/video.mp4" type="video/mp4">
+    <source src="/path/to/video.webm" type="video/webm">
+
+    <!-- Captions are optional -->
+    <track kind="captions" label="English captions" src="/path/to/captions.vtt" srclang="en" default>
+</video>
+p = @lesson.description
+ul = link_to "Edit", edit_lesson_path(@lesson)
+ul = link_to "Back", lessons_path

--- a/app/views/static_pages/about.html.slim
+++ b/app/views/static_pages/about.html.slim
@@ -1,2 +1,12 @@
-h1 = t('global.about')
-p = t('.description')
+.mt-3.d-flex.small.p-2.custom-breadcrumbs
+  div
+    a title = t('global.home') href = root_path
+      i == Octicons::Octicon.new("home").to_svg
+  div
+    i == Octicons::Octicon.new("arrow-right").to_svg
+  div
+    = t('global.about')
+
+.my-3.p-3.bg-body.rounded.shadow-sm style = "height: 350px;"
+  h1 = t('global.about')
+  p = t('.description')

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -1,1 +1,2 @@
-p = t('.description')
+.my-3.p-3.bg-body.rounded.shadow-sm style = "height: 400px;"
+  p = t('.description')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,13 +4,16 @@ en:
       category:
         name: "Name"
         description: "Description"
-      lessons:
+      lesson:
         title: "Title"
         description: "Description"
         video_link: "Video link"
+        status: "Status"
+        category: "Category"
   global:
     home: "Home"
     categories: "Categories"
+    lessons: "Lessons"
     about: "About"
     login: "Log in"
     logout: "Log out"
@@ -22,7 +25,7 @@ en:
       title: "Learn dozens of quality courses with Lessoner"
       lead: "Best & free web platform for online learning"
     back: "Back"
-    edit: "Изменить"
+    edit: "Edit"
 
   static_pages:
     about:
@@ -70,3 +73,5 @@ en:
 
   lessons:
     add_new_lesson: "Add new lesson"
+    category_lessons: "Lessons from this category"
+    edit_lesson: "Edit lesson"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,10 @@ en:
       category:
         name: "Name"
         description: "Description"
-
+      lessons:
+        title: "Title"
+        description: "Description"
+        video_link: "Video link"
   global:
     home: "Home"
     categories: "Categories"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -5,10 +5,16 @@ ru:
         name: "Название"
         description: "Описание"
         status: 'Статус'
-
+      lesson:
+        title: "Заголовок"
+        description: "Описание"
+        video_link: "Ссылка на видео"
+        status: "Статус"
+        category: "Категория"
   global:
     home: "Домой"
     categories: "Категории"
+    lessons: "Уроки"
     about: "О проекте"
     login: "Войти"
     logout: "Выйти"
@@ -67,4 +73,5 @@ ru:
 
   lessons:
     add_new_lesson: "Добавить урок"
-
+    category_lessons: "Уроки в этой категории"
+    edit_lesson: "Редактировать урок"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,37 +14,37 @@
 
 ActiveRecord::Schema[7.0].define(version: 2022_09_11_183710) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "categories", force: :cascade do |t|
-    t.string "name"
-    t.string "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "status", default: 0
+  create_table 'categories', force: :cascade do |t|
+    t.string 'name'
+    t.string 'description'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'status', default: 0
   end
 
-  create_table "comments", force: :cascade do |t|
-    t.text "body"
-    t.bigint "lesson_id", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["lesson_id"], name: "index_comments_on_lesson_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
+  create_table 'comments', force: :cascade do |t|
+    t.text 'body'
+    t.bigint 'lesson_id', null: false
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['lesson_id'], name: 'index_comments_on_lesson_id'
+    t.index ['user_id'], name: 'index_comments_on_user_id'
   end
 
-  create_table "lessons", force: :cascade do |t|
-    t.string "description"
-    t.string "title"
-    t.string "video_link"
-    t.string "status"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "author_id"
-    t.bigint "category_id"
-    t.index ["author_id"], name: "index_lessons_on_author_id"
-    t.index ["category_id"], name: "index_lessons_on_category_id"
+  create_table 'lessons', force: :cascade do |t|
+    t.string 'description'
+    t.string 'title'
+    t.string 'video_link'
+    t.string 'status'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.bigint 'author_id'
+    t.bigint 'category_id'
+    t.index ['author_id'], name: 'index_lessons_on_author_id'
+    t.index ['category_id'], name: 'index_lessons_on_category_id'
   end
 
   create_table "users", force: :cascade do |t|
@@ -67,8 +69,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_11_183710) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "comments", "lessons"
-  add_foreign_key "comments", "users"
-  add_foreign_key "lessons", "categories"
-  add_foreign_key "lessons", "users", column: "author_id"
+  add_foreign_key 'comments', 'lessons'
+  add_foreign_key 'comments', 'users'
+  add_foreign_key 'lessons', 'categories'
+  add_foreign_key 'lessons', 'users', column: 'author_id'
 end

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LessonsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class LessonsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do

--- a/test/controllers/lessons_controller_test.rb
+++ b/test/controllers/lessons_controller_test.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'test_helper'
-
-class LessonsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
There is an updated Dima`s PR here.

- Conflicts are fixed
- Lessons are added
- 2 Rubocop rules are disabled in the .rubocop.yml
- Some FE issues are added and corrected over a number of site pages (page layout, forms, pagination)
- Header menu: 'Home' item is removed, 'Lessons' item is added
- Breadcrumbs are added, 'Back' button is removed from certain pages

Lessons logic:
- 'Add lesson', 'Edit' buttons are availbale for Authentificated user
- Authentificated user can edit any lesson (of any user)
- Not authentificated / Authenticated users can read any lesson
- /en/lessons page consists of all lessons
- each category page consists lessons of corresponded category